### PR TITLE
tools: add staticd line in daemon config file

### DIFF
--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -27,6 +27,7 @@ eigrpd=no
 babeld=no
 sharpd=no
 pbrd=no
+staticd=no
 bfdd=no
 fabricd=no
 vrrpd=no


### PR DESCRIPTION
default staticd=no was missing in daemon file

Signed-off-by: Emanuele Bovisio <emanuele.bovisio@eolo.it>