### PR TITLE
tools: add PIDFile option in frr.service

### DIFF
--- a/tools/frr.service
+++ b/tools/frr.service
@@ -17,6 +17,7 @@ WatchdogSec=60s
 RestartSec=5
 Restart=on-abnormal
 LimitNOFILE=1024
+PIDFile=/var/run/frr/watchfrr.pid
 ExecStart=/usr/lib/frr/frrinit.sh start
 ExecStop=/usr/lib/frr/frrinit.sh stop
 ExecReload=/usr/lib/frr/frrinit.sh reload


### PR DESCRIPTION
when type is forking, it is recommended to also use the PIDFile= option,
so that systemd can reliably identify the main process of the service.

