### PR TITLE
build: add more precious variables for cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ dnl -----------------------------------
 AC_CANONICAL_BUILD()
 AC_CANONICAL_HOST()
 
+AC_ARG_VAR([AR],[archiver command])
+AC_ARG_VAR([LD],[linker command])
+AC_ARG_VAR([OBJCOPY],[objcopy command])
+AC_ARG_VAR([OBJDUMP],[objdump command])
+AC_ARG_VAR([RANLIB],[ranlib command])
+AC_ARG_VAR([STRIP],[strip command])
+
 hosttools_clippy="false"
 build_clippy="true"
 


### PR DESCRIPTION
Using AC_ARG_VAR function, it's possible to add LD, AR, OBJCOPY,
OBJDUMP, RANLIB and STRIP to the list of precious variables in
$ac_precious_vars for configure tool.

Doing this, we are enabling a new set of variables (HOST_LD, HOST_AR,
HOST_OBJCOPY, HOST_OBJDUMP, HOST_RANLIB and HOST_STRIP) useful for
cross-compiling when the target toolchain is prepending a prefix
to these tools.
